### PR TITLE
Lower package minimum deployment targets for better compatibility with applications

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,11 +6,11 @@ let package = Package(
     name: "KickstartSDK",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v18),
-        .macOS(.v15),
-        .tvOS(.v18),
-        .watchOS(.v11),
-        .visionOS(.v2)
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+        .watchOS(.v8),
+        .visionOS(.v1)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Kickstart Exchange was designed for maximum user privacy. It matches apps, not p
 
 The package requires Xcode 26, and supports iOS 18, iPadOS 18, macOS 15, tvOS 18, watchOS 11, and visionOS 2 or later. It has no dependencies and is licensed under the MIT License.
 
+You can still add the package to an app whose deployment target is lower — down to iOS 15, iPadOS 15, macOS 12, tvOS 15, watchOS 8, and visionOS 1. In that case, wrap `ExchangeBannerAdView` and its modifiers in `#available` so they are only used on the supported OS versions.
+
 
 ## Installation
 
@@ -49,6 +51,14 @@ You're welcome to disable Kickstart Exchange at any time, including if users buy
 
 ```swift
 if hasPremiumAccess == false {
+    ExchangeBannerAdView(apiKey: "ks_live_REPLACE_WITH_API_KEY")
+}
+```
+
+If the app’s minimum OS version is below the supported versions, gate the same call:
+
+```swift
+if #available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *) {
     ExchangeBannerAdView(apiKey: "ks_live_REPLACE_WITH_API_KEY")
 }
 ```

--- a/Scripts/check-platform-public-api.sh
+++ b/Scripts/check-platform-public-api.sh
@@ -47,7 +47,7 @@ if rg -q '@testable|@_spi|^package[[:space:]]+import' "$external_fixture"; then
     exit 1
 fi
 
-for declaration in '.iOS(.v18)' '.macOS(.v15)' '.tvOS(.v18)' '.watchOS(.v11)' '.visionOS(.v2)'; do
+for declaration in '.iOS(.v15)' '.macOS(.v12)' '.tvOS(.v15)' '.watchOS(.v8)' '.visionOS(.v1)'; do
     if ! rg -Fq "$declaration" "$package_path/Package.swift"; then
         echo "Package.swift is missing its required $declaration deployment minimum." >&2
         exit 1
@@ -142,11 +142,11 @@ check_platform() {
     echo "Verified $platform_name ($target) by emitting the SDK module and type-checking tests and an external client in debug and release."
 }
 
-check_platform "iOS and iPadOS" ios iphoneos arm64-apple-ios18.0
+check_platform "iOS and iPadOS" ios iphoneos arm64-apple-ios15.0
 # Xcode stores the iOS SwiftUI macro plug-ins under the device platform.
-check_platform "iOS Simulator" ios-simulator iphonesimulator arm64-apple-ios18.0-simulator iphoneos
-check_platform "macOS" macos macosx arm64-apple-macosx15.0
-check_platform "Mac Catalyst" catalyst macosx arm64-apple-ios18.0-macabi
-check_platform "tvOS" tvos appletvos arm64-apple-tvos18.0
-check_platform "watchOS" watchos watchos arm64_32-apple-watchos11.0
-check_platform "visionOS" visionos xros arm64-apple-xros2.0
+check_platform "iOS Simulator" ios-simulator iphonesimulator arm64-apple-ios15.0-simulator iphoneos
+check_platform "macOS" macos macosx arm64-apple-macosx12.0
+check_platform "Mac Catalyst" catalyst macosx arm64-apple-ios15.0-macabi
+check_platform "tvOS" tvos appletvos arm64-apple-tvos15.0
+check_platform "watchOS" watchos watchos arm64_32-apple-watchos8.0
+check_platform "visionOS" visionos xros arm64-apple-xros1.0

--- a/Sources/KickstartExchange/ExchangeBannerAdView.swift
+++ b/Sources/KickstartExchange/ExchangeBannerAdView.swift
@@ -23,6 +23,7 @@ import SwiftUI
 //
 
 /// A fixed-format, privacy-preserving Kickstart Exchange banner advertisement.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 public struct ExchangeBannerAdView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase

--- a/Sources/KickstartExchange/Models/ExchangeAppTransactionEvidence.swift
+++ b/Sources/KickstartExchange/Models/ExchangeAppTransactionEvidence.swift
@@ -8,6 +8,7 @@
 import StoreKit
 
 /// Provides verified App Store transaction evidence for shipping builds.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 enum ExchangeAppTransactionEvidence {
     static func current() async -> String? {
         #if DEBUG || targetEnvironment(simulator)

--- a/Sources/KickstartExchange/Models/ExchangePlatform.swift
+++ b/Sources/KickstartExchange/Models/ExchangePlatform.swift
@@ -25,6 +25,7 @@ enum ExchangePlatform: String, Hashable, Sendable {
     case visionOS = "visionos"
 
     /// The platform this code is currently running on.
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @MainActor
     static var current: ExchangePlatform {
         #if os(watchOS)

--- a/Sources/KickstartExchange/Networking/ExchangeAPIClient.swift
+++ b/Sources/KickstartExchange/Networking/ExchangeAPIClient.swift
@@ -35,6 +35,7 @@ struct ExchangeAPIClient: Sendable {
 
     private let appTransaction: @Sendable () async -> String?
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     init(
         apiKey: String,
         bundleIdentifier: String,

--- a/Sources/KickstartExchange/State/ExchangeAdRunState.swift
+++ b/Sources/KickstartExchange/State/ExchangeAdRunState.swift
@@ -8,6 +8,7 @@
 import Observation
 
 /// Tracks whether advertising has been suppressed for the current app run.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 @MainActor
 @Observable
 final class ExchangeAdRunState {

--- a/Sources/KickstartExchange/State/ExchangeAdRunStore.swift
+++ b/Sources/KickstartExchange/State/ExchangeAdRunStore.swift
@@ -6,6 +6,7 @@
 //
 
 /// Shares advertisement acquisition and impression work across matching views.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 @MainActor
 final class ExchangeAdRunStore {
     static let shared = ExchangeAdRunStore()

--- a/Sources/KickstartExchange/State/ExchangeAdViewModel.swift
+++ b/Sources/KickstartExchange/State/ExchangeAdViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import ImageIO
 
 /// Loads, presents, and records interactions for a single Exchange banner.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 @MainActor
 @Observable
 final class ExchangeAdViewModel {

--- a/Sources/KickstartExchange/Styling/ExchangeAdStyleModifiers.swift
+++ b/Sources/KickstartExchange/Styling/ExchangeAdStyleModifiers.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 extension EnvironmentValues {
     @Entry var exchangeAdCornerStyle = ExchangeAdCornerStyle.rounded
     @Entry var exchangeAdStrokeColor: Color?
@@ -20,6 +21,7 @@ extension EnvironmentValues {
     #endif
 }
 
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 public extension View {
     /// Sets the corner treatment for Kickstart Exchange advertisement cards
     /// within this view.

--- a/Sources/KickstartExchange/Views/AppStoreActionButton.swift
+++ b/Sources/KickstartExchange/Views/AppStoreActionButton.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 /// Displays the action that opens an advertised app in the App Store.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 struct AppStoreActionButton: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.exchangeAdActionTextColor) private var textColor

--- a/Sources/KickstartExchange/Views/ExchangeAdvertisementCard.swift
+++ b/Sources/KickstartExchange/Views/ExchangeAdvertisementCard.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 /// Displays an advertised app's icon, copy, disclosure, and App Store action.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 struct ExchangeAdvertisementCard: View {
     let appName: String
     let subtitle: String?

--- a/Sources/KickstartExchange/Views/ExchangeAdvertisementInfoView.swift
+++ b/Sources/KickstartExchange/Views/ExchangeAdvertisementInfoView.swift
@@ -17,6 +17,7 @@ import SwiftUI
 //
 
 /// Explains an advertisement and provides navigation for reporting it.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 struct ExchangeAdvertisementInfoView: View {
     let presentation: ExchangeAdPresentation
     let isPreview: Bool

--- a/Sources/KickstartExchange/Views/ExchangeReportSubmissionView.swift
+++ b/Sources/KickstartExchange/Views/ExchangeReportSubmissionView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 /// Submits a selected report reason and displays the submission result.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 struct ExchangeReportSubmissionView: View {
     let reason: ExchangeReportReason
     let isPreview: Bool

--- a/Sources/KickstartExchange/Views/ExchangeReportView.swift
+++ b/Sources/KickstartExchange/Views/ExchangeReportView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 /// Presents the available reasons for reporting an advertisement.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 struct ExchangeReportView: View {
     let close: @MainActor @Sendable () -> Void
 

--- a/Tests/KickstartExchangeTests/AsyncTestWaiter.swift
+++ b/Tests/KickstartExchangeTests/AsyncTestWaiter.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// Polls an asynchronous condition until it succeeds or reaches a timeout.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 @MainActor
 enum AsyncTestWaiter {
     static func until(

--- a/Tests/KickstartExchangeTests/EventDeliveryDiagnosticsTests.swift
+++ b/Tests/KickstartExchangeTests/EventDeliveryDiagnosticsTests.swift
@@ -13,6 +13,7 @@ import Testing
 @MainActor
 @Suite("Development impression diagnostics")
 struct EventDeliveryDiagnosticsTests {
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("A development impression failure reports once")
     func developmentFailureReports() async throws {
         let handler = readyHandler(impression: .failure(URLError(.timedOut)))
@@ -27,6 +28,7 @@ struct EventDeliveryDiagnosticsTests {
         #expect(recorder.messages == [Self.impressionDiagnostic])
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("Shipping impression failures remain quiet")
     func shippingFailureStaysQuiet() async throws {
         let handler = readyHandler(
@@ -48,6 +50,7 @@ struct EventDeliveryDiagnosticsTests {
         #expect(recorder.messages.isEmpty)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("Canceled impression delivery remains quiet")
     func cancellationStaysQuiet() async throws {
         let handler = readyHandler(impression: .failure(URLError(.cancelled)))
@@ -81,6 +84,7 @@ struct EventDeliveryDiagnosticsTests {
         ])
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     private func makeModel(
         handler: MockRequestHandler,
         recorder: DiagnosticRecorder,

--- a/Tests/KickstartExchangeTests/ExchangeEnvironmentTests.swift
+++ b/Tests/KickstartExchangeTests/ExchangeEnvironmentTests.swift
@@ -13,6 +13,7 @@ import Testing
 @MainActor
 @Suite("Build environment")
 struct ExchangeEnvironmentTests {
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("The view model defaults to the current build environment")
     func defaultDevelopmentWiring() async throws {
         let handler = MockRequestHandler([

--- a/Tests/KickstartExchangeTests/LoadDiagnosticsTests.swift
+++ b/Tests/KickstartExchangeTests/LoadDiagnosticsTests.swift
@@ -13,6 +13,7 @@ import Testing
 @MainActor
 @Suite("Development load diagnostics")
 struct LoadDiagnosticsTests {
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("A missing bundle identifier produces one actionable diagnostic")
     func missingBundleIdentifier() async {
         let handler = MockRequestHandler()
@@ -39,6 +40,7 @@ struct LoadDiagnosticsTests {
         #expect(await handler.requests().isEmpty)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("A session rejection keeps its actionable reason")
     func sessionRejection() async {
         let rejected = TestFixtures.response(
@@ -61,6 +63,7 @@ struct LoadDiagnosticsTests {
         ])
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("An unexpected serve response produces one service diagnostic")
     func unexpectedServeResponse() async {
         let handler = MockRequestHandler([
@@ -82,6 +85,7 @@ struct LoadDiagnosticsTests {
         #expect(await handler.requests().count == 2)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     private func makeModel(
         handler: MockRequestHandler,
         recorder: DiagnosticRecorder

--- a/Tests/KickstartExchangeTests/PresentationLayoutTests.swift
+++ b/Tests/KickstartExchangeTests/PresentationLayoutTests.swift
@@ -15,6 +15,7 @@ import Testing
 @Suite("Advertisement presentation layout")
 @MainActor
 struct PresentationLayoutTests {
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("The card adapts its height at narrow widths")
     func narrowCardAdaptsItsHeight() {
         let regularSize = cardSize(width: 320)
@@ -25,6 +26,7 @@ struct PresentationLayoutTests {
         #expect(narrowSize.height > regularSize.height)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     private func cardSize(width: Double) -> CGSize {
         let card = ExchangeAdvertisementCard(
             appName: "A Thirty Character App Name!",

--- a/Tests/KickstartExchangeTests/PrivacyManifestTests.swift
+++ b/Tests/KickstartExchangeTests/PrivacyManifestTests.swift
@@ -11,6 +11,7 @@ import Testing
 /// Verifies the SDK privacy manifest declares its exact data practices.
 @Suite("Privacy manifest")
 struct PrivacyManifestTests {
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("The manifest declares the exact Exchange data types and purposes")
     func exactDataTypesAndPurposes() throws {
         let packageRoot = URL(filePath: #filePath)

--- a/Tests/KickstartExchangeTests/PublicAPIFixture.swift
+++ b/Tests/KickstartExchangeTests/PublicAPIFixture.swift
@@ -9,6 +9,7 @@ import KickstartExchange
 import SwiftUI
 
 /// Compiles representative uses of the SDK's public SwiftUI API.
+@available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
 @MainActor
 private struct PublicAPIFixture: View {
     var body: some View {

--- a/Tests/KickstartExchangeTests/ViewModelTests.swift
+++ b/Tests/KickstartExchangeTests/ViewModelTests.swift
@@ -13,6 +13,7 @@ import Testing
 @MainActor
 @Suite("Advertisement lifecycle")
 struct ViewModelTests {
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("Preview loads without sessions or accounting")
     func previewAdvert() async throws {
         let handler = MockRequestHandler([
@@ -42,6 +43,7 @@ struct ViewModelTests {
         #expect(requests[2].url?.absoluteString == TestFixtures.previewClickURL)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("A failed preview click still returns the direct store URL")
     func failedPreviewClickUsesFallback() async throws {
         let handler = MockRequestHandler([
@@ -61,6 +63,7 @@ struct ViewModelTests {
         #expect(model.isOpeningStore == false)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("Preview reports exercise the API without a live serve")
     func previewReport() async throws {
         let handler = MockRequestHandler([
@@ -86,6 +89,7 @@ struct ViewModelTests {
         #expect(body["reason"] as? String == "other")
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("Preview is unavailable in shipping builds")
     func shippingPreviewIsUnavailable() async {
         let handler = MockRequestHandler([])
@@ -104,6 +108,7 @@ struct ViewModelTests {
         #expect(diagnostic.contains("preview key is available only"))
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("A valid session, ad, and artwork become ready after one load")
     func readyState() async {
         let handler = readyHandler()
@@ -116,6 +121,7 @@ struct ViewModelTests {
         #expect(await handler.requests().count == 3)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("Every banner in one app run reuses the same advert")
     func bannersReuseAdvert() async {
         let handler = readyHandler()
@@ -137,6 +143,7 @@ struct ViewModelTests {
         #expect(await handler.requests().count == 3)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("A tap records quietly before returning the store URL and ignores repeats")
     func tapRecordsBeforeOpeningStore() async throws {
         let handler = readyHandler(
@@ -169,6 +176,7 @@ struct ViewModelTests {
         })
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("Visibility must remain continuous for a full second")
     func interruptedVisibility() async throws {
         let handler = readyHandler(
@@ -193,6 +201,7 @@ struct ViewModelTests {
         #expect(body["impression_token"] as? String == TestFixtures.impressionToken)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("All banners in one app run share one impression delivery")
     func bannersShareImpression() async {
         let handler = readyHandler(
@@ -222,6 +231,7 @@ struct ViewModelTests {
         #expect(await handler.requests().count == 4)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("An accepted report suppresses every banner for the app run")
     func reportSuppressesAllBanners() async {
         let handler = readyHandler(
@@ -250,6 +260,7 @@ struct ViewModelTests {
         #expect(await handler.requests().count == 4)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("A failed report leaves the shared advert visible")
     func failedReportRemainsVisible() async {
         let handler = readyHandler(
@@ -276,6 +287,7 @@ struct ViewModelTests {
         ] + additional, suspendedRequestNumber: suspendedRequestNumber)
     }
 
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     private func makeModel(
         apiKey: String = TestFixtures.apiKey,
         handler: MockRequestHandler,

--- a/Tests/KickstartExchangeTests/WireContractTests.swift
+++ b/Tests/KickstartExchangeTests/WireContractTests.swift
@@ -12,6 +12,7 @@ import Testing
 /// Verifies the SDK remains compatible with the shared Exchange API contract.
 @Suite("Exchange wire contract")
 struct WireContractTests {
+    @available(iOS 18, macOS 15, tvOS 18, watchOS 11, visionOS 2, *)
     @Test("SDK endpoints and response fields match the shared contract")
     func sharedContract() throws {
         let fixtureURL = try #require(Bundle.module.url(


### PR DESCRIPTION
Applications that support older platforms deserve to participate in Kickstart Exchange too!
This PR allows the package to be integrated into applications deploying to iOS 15, macOS 12, tvOS 15, and watchOS 8, as well as visionOS 1.
The ExchangeBannerAdView and its associated modifiers remain available only when run on iOS 18, macOS 15, tvOS 18, watchOS 11, and visionOS 2.
Gracefully degrading features on older OS versions fully complies with Apple guidelines.