### PR TITLE
Add an example app and workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 !/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
 /.DS_Store
 **/.DS_Store
+xcuserdata/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,3 +26,4 @@ type_body_length:
 included:
     - Sources
     - Tests
+    - Example

--- a/Example/KickstartExchangeExample.xcodeproj/project.pbxproj
+++ b/Example/KickstartExchangeExample.xcodeproj/project.pbxproj
@@ -1,0 +1,335 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		ADEE0001CC000001DD000001 /* KickstartExchangeExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE0002CC000002DD000002 /* KickstartExchangeExampleApp.swift */; };
+		ADEE0003CC000003DD000003 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE0004CC000004DD000004 /* ContentView.swift */; };
+		ADEE0005CC000005DD000005 /* PinnedBannerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE0006CC000006DD000006 /* PinnedBannerExample.swift */; };
+		ADEE001BCC00001BDD00001B /* ScrollingBannerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE001CCC00001CDD00001C /* ScrollingBannerExample.swift */; };
+		ADEE001DCC00001DDD00001D /* StyledBannerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEE001ECC00001EDD00001E /* StyledBannerExample.swift */; };
+		ADEE0007CC000007DD000007 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ADEE0008CC000008DD000008 /* Assets.xcassets */; };
+		ADEE0009CC000009DD000009 /* KickstartExchange in Frameworks */ = {isa = PBXBuildFile; productRef = ADEE000ACC00000ADD00000A /* KickstartExchange */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		ADEE0002CC000002DD000002 /* KickstartExchangeExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KickstartExchangeExampleApp.swift; sourceTree = "<group>"; };
+		ADEE0004CC000004DD000004 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		ADEE0006CC000006DD000006 /* PinnedBannerExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedBannerExample.swift; sourceTree = "<group>"; };
+		ADEE001CCC00001CDD00001C /* ScrollingBannerExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingBannerExample.swift; sourceTree = "<group>"; };
+		ADEE001ECC00001EDD00001E /* StyledBannerExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledBannerExample.swift; sourceTree = "<group>"; };
+		ADEE0008CC000008DD000008 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		ADEE000BCC00000BDD00000B /* KickstartExchangeExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KickstartExchangeExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		ADEE000CCC00000CDD00000C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ADEE0009CC000009DD000009 /* KickstartExchange in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		ADEE000DCC00000DDD00000D = {
+			isa = PBXGroup;
+			children = (
+				ADEE000ECC00000EDD00000E /* KickstartExchangeExample */,
+				ADEE000FCC00000FDD00000F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		ADEE000ECC00000EDD00000E /* KickstartExchangeExample */ = {
+			isa = PBXGroup;
+			children = (
+				ADEE0002CC000002DD000002 /* KickstartExchangeExampleApp.swift */,
+				ADEE0004CC000004DD000004 /* ContentView.swift */,
+				ADEE0006CC000006DD000006 /* PinnedBannerExample.swift */,
+				ADEE001CCC00001CDD00001C /* ScrollingBannerExample.swift */,
+				ADEE001ECC00001EDD00001E /* StyledBannerExample.swift */,
+				ADEE0008CC000008DD000008 /* Assets.xcassets */,
+			);
+			path = KickstartExchangeExample;
+			sourceTree = "<group>";
+		};
+		ADEE000FCC00000FDD00000F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				ADEE000BCC00000BDD00000B /* KickstartExchangeExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		ADEE0010CC000010DD000010 /* KickstartExchangeExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ADEE0011CC000011DD000011 /* Build configuration list for PBXNativeTarget "KickstartExchangeExample" */;
+			buildPhases = (
+				ADEE0012CC000012DD000012 /* Sources */,
+				ADEE000CCC00000CDD00000C /* Frameworks */,
+				ADEE0013CC000013DD000013 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = KickstartExchangeExample;
+			packageProductDependencies = (
+				ADEE000ACC00000ADD00000A /* KickstartExchange */,
+			);
+			productName = KickstartExchangeExample;
+			productReference = ADEE000BCC00000BDD00000B /* KickstartExchangeExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		ADEE0014CC000014DD000014 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
+				TargetAttributes = {
+					ADEE0010CC000010DD000010 = {
+						CreatedOnToolsVersion = 26.6;
+					};
+				};
+			};
+			buildConfigurationList = ADEE0015CC000015DD000015 /* Build configuration list for PBXProject "KickstartExchangeExample" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = ADEE000DCC00000DDD00000D;
+			packageReferences = (
+				ADEE0016CC000016DD000016 /* XCLocalSwiftPackageReference ".." */,
+			);
+			productRefGroup = ADEE000FCC00000FDD00000F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				ADEE0010CC000010DD000010 /* KickstartExchangeExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		ADEE0013CC000013DD000013 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ADEE0007CC000007DD000007 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		ADEE0012CC000012DD000012 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ADEE0001CC000001DD000001 /* KickstartExchangeExampleApp.swift in Sources */,
+				ADEE0003CC000003DD000003 /* ContentView.swift in Sources */,
+				ADEE0005CC000005DD000005 /* PinnedBannerExample.swift in Sources */,
+				ADEE001BCC00001BDD00001B /* ScrollingBannerExample.swift in Sources */,
+				ADEE001DCC00001DDD00001D /* StyledBannerExample.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		ADEE0017CC000017DD000017 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		ADEE0018CC000018DD000018 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		ADEE0019CC000019DD000019 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = tools.kickstart.KickstartExchangeExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		ADEE001ACC00001ADD00001A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = tools.kickstart.KickstartExchangeExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		ADEE0011CC000011DD000011 /* Build configuration list for PBXNativeTarget "KickstartExchangeExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ADEE0019CC000019DD000019 /* Debug */,
+				ADEE001ACC00001ADD00001A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ADEE0015CC000015DD000015 /* Build configuration list for PBXProject "KickstartExchangeExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ADEE0017CC000017DD000017 /* Debug */,
+				ADEE0018CC000018DD000018 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		ADEE0016CC000016DD000016 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		ADEE000ACC00000ADD00000A /* KickstartExchange */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = ADEE0016CC000016DD000016 /* XCLocalSwiftPackageReference ".." */;
+			productName = KickstartExchange;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = ADEE0014CC000014DD000014 /* Project object */;
+}

--- a/Example/KickstartExchangeExample.xcodeproj/xcshareddata/xcschemes/KickstartExchangeExample.xcscheme
+++ b/Example/KickstartExchangeExample.xcodeproj/xcshareddata/xcschemes/KickstartExchangeExample.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ADEE0010CC000010DD000010"
+               BuildableName = "KickstartExchangeExample.app"
+               BlueprintName = "KickstartExchangeExample"
+               ReferencedContainer = "container:KickstartExchangeExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ADEE0010CC000010DD000010"
+            BuildableName = "KickstartExchangeExample.app"
+            BlueprintName = "KickstartExchangeExample"
+            ReferencedContainer = "container:KickstartExchangeExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ADEE0010CC000010DD000010"
+            BuildableName = "KickstartExchangeExample.app"
+            BlueprintName = "KickstartExchangeExample"
+            ReferencedContainer = "container:KickstartExchangeExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/KickstartExchangeExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/KickstartExchangeExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/KickstartExchangeExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/KickstartExchangeExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/KickstartExchangeExample/Assets.xcassets/Contents.json
+++ b/Example/KickstartExchangeExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/KickstartExchangeExample/ContentView.swift
+++ b/Example/KickstartExchangeExample/ContentView.swift
@@ -1,0 +1,45 @@
+//
+// ContentView.swift
+// KickstartSDK
+// https://github.com/twostraws/KickstartSDK
+// See LICENSE for license information.
+//
+
+import SwiftUI
+
+/// Lists the advertisement placements this example demonstrates.
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    NavigationLink("Pinned to the bottom") {
+                        PinnedBannerExample()
+                    }
+
+                    NavigationLink("Inside a scrolling list") {
+                        ScrollingBannerExample()
+                    }
+
+                    NavigationLink("With custom styling") {
+                        StyledBannerExample()
+                    }
+                } header: {
+                    Text("Placements")
+                } footer: {
+                    Text(
+                        """
+                        Every screen uses the "preview" API key, so Debug builds \
+                        and the Simulator show a sample advert that charges nobody.
+                        """
+                    )
+                }
+            }
+            .navigationTitle("Kickstart Exchange")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Example/KickstartExchangeExample/KickstartExchangeExampleApp.swift
+++ b/Example/KickstartExchangeExample/KickstartExchangeExampleApp.swift
@@ -1,0 +1,27 @@
+//
+// KickstartExchangeExampleApp.swift
+// KickstartSDK
+// https://github.com/twostraws/KickstartSDK
+// See LICENSE for license information.
+//
+
+import SwiftUI
+
+//
+// Note to reader: this example app exists so you can see the SDK
+// running without an Exchange account. Every screen passes the
+// "preview" API key, which Debug builds and the Simulator answer
+// with a real server response for a sample advert. Nobody is
+// charged, nothing is counted, and the integration path - session,
+// serve, artwork, impression, click - is exercised for real.
+//
+
+/// Demonstrates Kickstart Exchange advertisement placements.
+@main
+struct KickstartExchangeExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Example/KickstartExchangeExample/PinnedBannerExample.swift
+++ b/Example/KickstartExchangeExample/PinnedBannerExample.swift
@@ -1,0 +1,31 @@
+//
+// PinnedBannerExample.swift
+// KickstartSDK
+// https://github.com/twostraws/KickstartSDK
+// See LICENSE for license information.
+//
+
+import KickstartExchange
+import SwiftUI
+
+/// Pins an advertisement below the content, which is the placement most apps
+/// reach for when asking people to pay to remove ads.
+struct PinnedBannerExample: View {
+    var body: some View {
+        List(1...50, id: \.self) { row in
+            Text("Row \(row)")
+        }
+        .safeAreaInset(edge: .bottom) {
+            ExchangeBannerAdView(apiKey: "preview")
+                .padding()
+        }
+        .navigationTitle("Pinned")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PinnedBannerExample()
+    }
+}

--- a/Example/KickstartExchangeExample/ScrollingBannerExample.swift
+++ b/Example/KickstartExchangeExample/ScrollingBannerExample.swift
@@ -1,0 +1,51 @@
+//
+// ScrollingBannerExample.swift
+// KickstartSDK
+// https://github.com/twostraws/KickstartSDK
+// See LICENSE for license information.
+//
+
+import KickstartExchange
+import SwiftUI
+
+//
+// Note to reader: scroll the advertisement off screen and back on
+// again. The SDK only records an impression once the card has been
+// at least half visible for a full second, and only once per app
+// run - so scrolling past it repeatedly does not inflate anything.
+//
+
+/// Places an advertisement between rows of scrolling content, where the SDK's
+/// viewability tracking decides when the card has genuinely been seen.
+struct ScrollingBannerExample: View {
+    var body: some View {
+        List {
+            Section {
+                ForEach(1...5, id: \.self) { row in
+                    Text("Row \(row)")
+                }
+            }
+
+            Section {
+                ExchangeBannerAdView(apiKey: "preview")
+                    .listRowInsets(.init(top: 2, leading: 2, bottom: 2, trailing: 2))
+                    .listRowBackground(Color.clear)
+            }
+
+            Section {
+                ForEach(6...20, id: \.self) { row in
+                    Text("Row \(row)")
+                }
+            }
+        }
+        .navigationTitle("In a list")
+        .navigationBarTitleDisplayMode(.inline)
+        .listSectionSpacing(8)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ScrollingBannerExample()
+    }
+}

--- a/Example/KickstartExchangeExample/StyledBannerExample.swift
+++ b/Example/KickstartExchangeExample/StyledBannerExample.swift
@@ -1,0 +1,45 @@
+//
+// StyledBannerExample.swift
+// KickstartSDK
+// https://github.com/twostraws/KickstartSDK
+// See LICENSE for license information.
+//
+
+import KickstartExchange
+import SwiftUI
+
+/// Applies each Kickstart Exchange styling modifier so you can see how far the
+/// card bends to match an app's design without hiding the advert disclosure.
+struct StyledBannerExample: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 32) {
+                ExchangeBannerAdView(apiKey: "preview")
+                    .exchangeAdCornerStyle(.square)
+
+                ExchangeBannerAdView(apiKey: "preview")
+                    .exchangeAdCornerStyle(.rounded)
+                    .exchangeAdStroke(.orange)
+                    .exchangeAdActionTextColor(.orange)
+                    .exchangeAdDisclosureBackgroundColor(.purple)
+
+                ExchangeBannerAdView.preview(
+                    appName: "Example App",
+                    subtitle: "A deterministic preview card",
+                    icon: Image(systemName: "app.fill")
+                )
+                .exchangeAdActionTextColor(.green)
+                .exchangeAdDisclosureBackgroundColor(.indigo)
+            }
+            .padding()
+        }
+        .navigationTitle("Styling")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        StyledBannerExample()
+    }
+}

--- a/KickstartSDK.xcworkspace/contents.xcworkspacedata
+++ b/KickstartSDK.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Example/KickstartExchangeExample.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:">
+   </FileRef>
+</Workspace>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Kickstart Exchange was designed for maximum user privacy. It matches apps, not p
 
 The package requires Xcode 26, and supports iOS 18, iPadOS 18, macOS 15, tvOS 18, watchOS 11, and visionOS 2 or later. It has no dependencies and is licensed under the MIT License.
 
-
 ## Installation
 
 Add `https://github.com/twostraws/KickstartSDK` in Xcode, then link the `KickstartExchange` product to your app target.
@@ -55,7 +54,6 @@ if hasPremiumAccess == false {
 
 Real adverts are shown automatically when your app goes live. **Note:** Simulator doesn’t support previewing App Store links.
 
-
 ## Previewing and styling
 
 You can preview banner ads in Xcode like this:
@@ -90,13 +88,17 @@ Like other SwiftUI modifiers these flow down through the environment, so applyin
 
 **Important:** This SDK is released under the MIT License, so you are free to inspect, modify, and redistribute it, including as part of your own service. However, only unmodified versions of this SDK may connect to the official Kickstart Exchange service. Modified versions may be blocked, and apps using them may be removed from Kickstart Exchange.
 
-
 ## Testing your integration
 
 Debug builds and the Simulator automatically ask Kickstart Exchange for a *test advert*: a real response from the live service, so seeing the card is proof your API key, bundle identifier, and network path all work. Test adverts charge nobody, earn nothing, and are never counted in analytics, and they work even before Kickstart Exchange begins serving.
 
 If no card appears while testing, or if the SDK cannot record a test ad impression, check Xcode's debug console for errors explaining what failed and what to try next. For shipping builds, check the Integration card in the Exchange dashboard.
 
+## Example app
+
+`KickstartSDK.xcworkspace` contains the package alongside a small iOS example app in `Example/`. Open the workspace, choose the **KickstartExchangeExample** scheme, and run it in the Simulator to see each placement without an Exchange account – every screen uses the `preview` API key, so the adverts you see are test adverts that charge nobody.
+
+The example covers pinning a banner beneath your content, placing one between rows of a scrolling list so you can watch viewability tracking decide when the card has really been seen, and applying each styling modifier.
 
 ## Privacy and data flow
 
@@ -114,13 +116,11 @@ When someone taps an advert, the SDK records the click then opens the direct `ap
 
 If the advertiser has added an App Store Connect provider token, that App Store destination also contains Apple's provider token and the `KickstartExchange` campaign token. Apple may show the advertiser privacy-protected campaign results such as product-page views, downloads, usage, sales, and subscriptions, but that's all handled by Apple through App Store Connect – Kickstart Exchange does not receive those App Store conversion details.
 
-
 ## App Store privacy disclosure
 
 The included privacy manifest declares **Usage Data: Product Interaction** and **Usage Data: Advertising Data** for Third-Party Advertising, Developer's Advertising or Marketing, Analytics, and App Functionality – please make sure these are both declared on App Store Connect, in addition to any other privacy settings for your app. Both data types are unlinked from identity and are not used for tracking.
 
 App developers remain responsible for disclosing everything collected by their app and every other integrated SDK. Please follow the [exact App Store Connect steps](https://exchange.kickstart.tools/guide#app-privacy), keep any additional disclosures your app requires, and provide your own complete privacy policy that mentions and links to Kickstart Exchange.
-
 
 ## Contributing
 
@@ -129,7 +129,6 @@ We welcome all contributions, whether that's fixing up existing code, adding com
 - You must comment your code thoroughly, using documentation comments or regular comments as applicable.
 - All code must be licensed under the MIT license so it can benefit the most people.
 - Please ensure SwiftLint runs cleanly with no violations.
-
 
 ## License
 


### PR DESCRIPTION
Adds `KickstartSDK.xcworkspace`, which opens the package alongside a small iOS example app, so contributors can see and test advert placements without wiring up a host app of their own.

Every screen passes the "preview" API key, so the app runs in the Simulator with no Exchange account: a banner pinned beneath content, a banner between rows of a scrolling list where view-ability tracking decides when the card has really been seen, and a screen applying each styling modifier.

Also ignores `xcuserdata`, now that a project and workspace are checked in, and adds Example to the SwiftLint include list so the sample code is held to the same standard as the SDK.